### PR TITLE
Update the plugin's config argument to use api_token instead of fly_api_token

### DIFF
--- a/config/fly.spc
+++ b/config/fly.spc
@@ -3,6 +3,6 @@ connection "fly" {
 
   # Fly.io API token. Required.
   # To generate the token please visit https://fly.io/docs/flyctl/auth-token/
-  # This can also be set via the `API_TOKEN` environment variable.
+  # This can also be set via the `FLY_API_TOKEN` environment variable.
   # api_token = "97GtVsdAPwowRToaWDtgZtILdXI_agszONwajQslZ1o"
 }

--- a/config/fly.spc
+++ b/config/fly.spc
@@ -1,8 +1,8 @@
 connection "fly" {
   plugin = "fly"
 
-  # Fly.io API token.
+  # Fly.io API token. Required.
   # To generate the token please visit https://fly.io/docs/flyctl/auth-token/
-  # This can also be set via the `FLY_API_TOKEN` environment variable.
-  # fly_api_token = "97GtVsdAPwowRToaWDtgZtILdXI_agszONwajQslZ1o"
+  # This can also be set via the `API_TOKEN` environment variable.
+  # api_token = "97GtVsdAPwowRToaWDtgZtILdXI_agszONwajQslZ1o"
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -58,7 +58,7 @@ steampipe plugin install fly
 | Credentials | Fly requires an [API token](https://fly.io/docs/flyctl/auth-token/) for all requests.                                                                                  |
 | Permissions | API tokens have the same permissions as the user who creates them, and if the user permissions change, the API token permissions also change.                          |
 | Radius      | Each connection represents a single Fly Installation.                                                                                                                  |
-| Resolution  | 1. Credentials explicitly set in a steampipe config file (`~/.steampipe/config/fly.spc`)<br />2. Credentials specified in environment variable, e.g., `FLY_API_TOKEN`. |
+| Resolution  | 1. Credentials explicitly set in a steampipe config file (`~/.steampipe/config/fly.spc`)<br />2. Credentials specified in environment variable, e.g., `API_TOKEN`. |
 
 ### Configuration
 
@@ -70,17 +70,17 @@ connection "fly" {
 
   # Fly.io API token.
   # To generate the token please visit https://fly.io/docs/flyctl/auth-token/
-  # This can also be set via the `FLY_API_TOKEN` environment variable.
-  # fly_api_token = "97GtVsdAPwowRToaWDtgZtILdXI_agszONwajQslZ1o"
+  # This can also be set via the `API_TOKEN` environment variable.
+  # api_token = "97GtVsdAPwowRToaWDtgZtILdXI_agszONwajQslZ1o"
 }
 ```
 
 ### Credentials from Environment Variables
 
-The Fly plugin will use the standard Fly environment variables to obtain credentials **only if other argument (`fly_api_token`) is not specified** in the connection:
+The Fly plugin will use the standard Fly environment variables to obtain credentials **only if other argument (`api_token`) is not specified** in the connection:
 
 ```sh
-export FLY_API_TOKEN=97GtVsdAPwowRToaWDtgZtILdXI_agszONwajQslZ1o
+export API_TOKEN=97GtVsdAPwowRToaWDtgZtILdXI_agszONwajQslZ1o
 ```
 
 ## Get involved

--- a/docs/index.md
+++ b/docs/index.md
@@ -58,7 +58,7 @@ steampipe plugin install fly
 | Credentials | Fly requires an [API token](https://fly.io/docs/flyctl/auth-token/) for all requests.                                                                                  |
 | Permissions | API tokens have the same permissions as the user who creates them, and if the user permissions change, the API token permissions also change.                          |
 | Radius      | Each connection represents a single Fly Installation.                                                                                                                  |
-| Resolution  | 1. Credentials explicitly set in a steampipe config file (`~/.steampipe/config/fly.spc`)<br />2. Credentials specified in environment variable, e.g., `API_TOKEN`. |
+| Resolution  | 1. Credentials explicitly set in a steampipe config file (`~/.steampipe/config/fly.spc`)<br />2. Credentials specified in environment variable, e.g., `FLY_API_TOKEN`. |
 
 ### Configuration
 
@@ -70,7 +70,7 @@ connection "fly" {
 
   # Fly.io API token.
   # To generate the token please visit https://fly.io/docs/flyctl/auth-token/
-  # This can also be set via the `API_TOKEN` environment variable.
+  # This can also be set via the `FLY_API_TOKEN` environment variable.
   # api_token = "97GtVsdAPwowRToaWDtgZtILdXI_agszONwajQslZ1o"
 }
 ```
@@ -80,7 +80,7 @@ connection "fly" {
 The Fly plugin will use the standard Fly environment variables to obtain credentials **only if other argument (`api_token`) is not specified** in the connection:
 
 ```sh
-export API_TOKEN=97GtVsdAPwowRToaWDtgZtILdXI_agszONwajQslZ1o
+export FLY_API_TOKEN=97GtVsdAPwowRToaWDtgZtILdXI_agszONwajQslZ1o
 ```
 
 ## Get involved

--- a/fly/connection_config.go
+++ b/fly/connection_config.go
@@ -6,11 +6,11 @@ import (
 )
 
 type flyConfig struct {
-	FlyApiToken *string `cty:"fly_api_token"`
+	ApiToken *string `cty:"api_token"`
 }
 
 var ConfigSchema = map[string]*schema.Attribute{
-	"fly_api_token": {
+	"api_token": {
 		Type: schema.TypeString,
 	},
 }

--- a/fly/service.go
+++ b/fly/service.go
@@ -24,22 +24,22 @@ func getClient(ctx context.Context, d *plugin.QueryData) (*flyapi.Client, error)
 	/*
 		precedence of credentials:
 		- Credentials set in config
-		- FLY_API_TOKEN env var
+		- API_TOKEN env var
 	*/
 	var token string
-	token = os.Getenv("FLY_API_TOKEN")
+	token = os.Getenv("API_TOKEN")
 
-	if flyConfig.FlyApiToken != nil {
-		token = *flyConfig.FlyApiToken
+	if flyConfig.ApiToken != nil {
+		token = *flyConfig.ApiToken
 	}
 
 	// Return if no credential specified
 	if token == "" {
-		return nil, fmt.Errorf("fly_api_token must be configured")
+		return nil, fmt.Errorf("api_token must be configured")
 	}
 
 	// Start with an empty Fly config
-	config := flyapi.ClientConfig{FlyApiToken: flyConfig.FlyApiToken}
+	config := flyapi.ClientConfig{ApiToken: flyConfig.ApiToken}
 
 	// Create the client
 	client, err := flyapi.CreateClient(ctx, config)

--- a/fly/service.go
+++ b/fly/service.go
@@ -24,10 +24,10 @@ func getClient(ctx context.Context, d *plugin.QueryData) (*flyapi.Client, error)
 	/*
 		precedence of credentials:
 		- Credentials set in config
-		- API_TOKEN env var
+		- FLY_API_TOKEN env var
 	*/
 	var token string
-	token = os.Getenv("API_TOKEN")
+	token = os.Getenv("FLY_API_TOKEN")
 
 	if flyConfig.ApiToken != nil {
 		token = *flyConfig.ApiToken

--- a/flyapi/client.go
+++ b/flyapi/client.go
@@ -17,10 +17,10 @@ type Client struct {
 }
 
 func CreateClient(ctx context.Context, config ClientConfig) (*Client, error) {
-	h := http.Client{Timeout: 60 * time.Second, Transport: &utils.Transport{UnderlyingTransport: http.DefaultTransport, Token: *config.FlyApiToken, Ctx: ctx}}
+	h := http.Client{Timeout: 60 * time.Second, Transport: &utils.Transport{UnderlyingTransport: http.DefaultTransport, Token: *config.ApiToken, Ctx: ctx}}
 
 	return &Client{
-		Token:   config.FlyApiToken,
+		Token:   config.ApiToken,
 		Graphql: graphql.NewClient("https://api.fly.io/graphql", &h),
 	}, nil
 }

--- a/flyapi/clientConfig.go
+++ b/flyapi/clientConfig.go
@@ -1,5 +1,5 @@
 package flyapi
 
 type ClientConfig struct {
-	FlyApiToken *string
+	ApiToken *string
 }


### PR DESCRIPTION
# Example query results
<details>
  <summary>Results</summary>

```
Add example SQL query results here (please include the input queries as well)
```
</details>
