### PR TITLE
Fix the plugin to correctly return results when environment variables are used for authentication

### DIFF
--- a/fly/service.go
+++ b/fly/service.go
@@ -33,13 +33,13 @@ func getClient(ctx context.Context, d *plugin.QueryData) (*flyapi.Client, error)
 		token = *flyConfig.ApiToken
 	}
 
-	// Return if no credential specified
+	// Return if no credential is specified
 	if token == "" {
 		return nil, fmt.Errorf("api_token must be configured")
 	}
 
 	// Start with an empty Fly config
-	config := flyapi.ClientConfig{ApiToken: flyConfig.ApiToken}
+	config := flyapi.ClientConfig{ApiToken: &token}
 
 	// Create the client
 	client, err := flyapi.CreateClient(ctx, config)


### PR DESCRIPTION

# Example query results
<details>
  <summary>Results</summary>

Before the fix:
```
select
  name,
  app_url,
  status,
  hostname
from
  fly_app limit 1;

Error: rpc error: code = Internal desc = hydrate function listFlyApps failed with panic runtime error: invalid memory address or nil pointer dereference (SQLSTATE HV000)

+------+---------+--------+----------+
| name | app_url | status | hostname |
+------+---------+--------+----------+
+------+---------+--------+----------+
```

After the fix:
```
select
  name,
  app_url,
  status,
  hostname
from
  fly_app;
+------+---------+--------+----------+
| name | app_url | status | hostname |
+------+---------+--------+----------+
+------+---------+--------+----------+
```
</details>
